### PR TITLE
test: add 2022 strategy and minimum supported version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [2023.1, 2023.1.2]
+        version: [2022.1.16, 2022.1, 2023.1]
     steps:
       - uses: actions/checkout@v4
 
@@ -49,7 +49,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        version: [2023.1, 2023.1.2]
+        version: [2022.1.16, 2022.1, 2023.1]
     steps:
       - uses: actions/checkout@v4
 
@@ -85,7 +85,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        version: [2023.1, 2023.1.2]
+        version: [2022.1.16, 2022.1, 2023.1]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Set up your GitHub Actions workflow with a specific version of Wwise SDK.
 
+> Minimum supported Wwise SDK version: `2022.1.16`
+
 ### Inputs
 
 | Name            | Description                                                                                                                                    |


### PR DESCRIPTION
Audiokinetic fixed #3 in 2022.1.16.

This PR document `2022.1.16` as the minimum supported Wwise SDK version and add 2022.1 test strategy.