### PR TITLE
fix: switch macos test ci runner to macos-13 for xcode 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
 
   test-macos:
     name: Test macOS
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         version: [2022.1.16, 2023.1, 2024.1]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [2022.1.16, 2022.1, 2023.1]
+        version: [2022.1.16, 2023.1, 2024.1]
     steps:
       - uses: actions/checkout@v4
 
@@ -49,7 +49,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        version: [2022.1.16, 2022.1, 2023.1]
+        version: [2022.1.16, 2023.1, 2024.1]
     steps:
       - uses: actions/checkout@v4
 
@@ -85,7 +85,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        version: [2022.1.16, 2022.1, 2023.1]
+        version: [2022.1.16, 2023.1, 2024.1]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Wwise SDK supports Xcode 14 and 15, we need use macos-13 runner image for testing ci.